### PR TITLE
Improve GitHub and WordPress.org plugin copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,86 @@
-# Disable XML-RPC by ProgressPlanner
+# Disable XML-RPC by Progress Planner
 
-![Disable XML-RPC](.wordpress.org/github_banner_disable_xml_rcp_pp.png)
+![Disable XML-RPC banner](.wordpress.org/github_banner_disable_xml_rcp_pp.png)
+
+A lightweight WordPress plugin that disables XML-RPC completely, helping reduce attack surface and block unwanted XML-RPC access with zero configuration.
+
+## Why use this plugin?
+
+If your site does not rely on XML-RPC, leaving it enabled serves little purpose and can create unnecessary exposure. This plugin turns XML-RPC off in a minimal, focused way.
+
+### Benefits
+
+- Disables XML-RPC for WordPress sites that do not need it
+- Returns a 403 response for XML-RPC requests
+- Works immediately after activation
+- No settings page, setup wizard, or maintenance overhead
+- Tiny codebase with a single, clear purpose
+
+## Who is this for?
+
+This plugin is a good fit for:
+
+- site owners who do not use XML-RPC-based publishing or integrations
+- agencies and developers hardening client sites
+- WordPress installs where XML-RPC is not part of the workflow
+
+## Important compatibility note
+
+Do **not** use this plugin if your site depends on XML-RPC for publishing or integrations. Disabling XML-RPC can affect tools or services that still rely on it.
+
+## Installation
+
+### From WordPress admin
+
+1. Go to **Plugins → Add New**.
+2. Search for **Disable XML-RPC by Progress Planner**.
+3. Install and activate the plugin.
+
+### From GitHub or a ZIP file
+
+1. Download this repository as a ZIP.
+2. Upload it via **Plugins → Add New → Upload Plugin**.
+3. Activate the plugin.
+
+## What happens after activation?
+
+Once activated, the plugin:
+
+- disables WordPress XML-RPC through the relevant filter
+- blocks XML-RPC requests directly
+- shows a clear “XML-RPC Disabled” response when access is attempted
+
+There are no settings to configure.
+
+## Frequently asked questions
+
+### Does this plugin have a settings page?
+
+No. It is intentionally configuration-free.
+
+### Will this improve security?
+
+It can help reduce exposure on sites that do not need XML-RPC. Like any hardening step, it should be part of a broader security strategy.
+
+### Will this break anything?
+
+It may, if you use a service, app, or workflow that still depends on XML-RPC. Review your stack before activating it on production sites.
+
+## Development
+
+This is a deliberately small utility plugin. If you want to review behavior, start with:
+
+- `pp-disable-xml-rpc.php`
+
+## License
+
+MIT. See [LICENSE](LICENSE).
+
+## Recommended GitHub About settings
+
+These cannot be fully managed from files alone, but they will improve the repository page:
+
+- **Description:** Disable WordPress XML-RPC completely with a lightweight, no-settings plugin.
+- **Website:** https://progressplanner.com/
+- **Topics:** `wordpress`, `wordpress-plugin`, `xml-rpc`, `security`, `hardening`, `site-security`, `progress-planner`
+- **Social preview:** Use `.wordpress.org/banner-1544x500.png` or create a 1280×640 social card based on the existing banner

--- a/pp-disable-xml-rpc.php
+++ b/pp-disable-xml-rpc.php
@@ -6,7 +6,7 @@
  *
  * Plugin name:       Disable XML-RPC by Progress Planner
  * Plugin URI:        https://progressplanner.com
- * Description:       A utility plugin to disable XML-RPC.
+ * Description:       Disable WordPress XML-RPC completely with a lightweight, no-settings hardening plugin.
  * Requires at least: 6.7
  * Tested up to:      6.9
  * Requires PHP:      7.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,66 @@
+=== Disable XML-RPC by Progress Planner ===
+Contributors: progressplanner
+Donate link: https://progressplanner.com/
+Tags: security, xml-rpc, hardening, disable xml-rpc
+Requires at least: 6.7
+Tested up to: 6.9
+Requires PHP: 7.4
+Stable tag: 1.6.1
+License: MIT
+License URI: https://mit-license.org
+
+Disable WordPress XML-RPC completely with a lightweight, no-settings plugin.
+
+== Description ==
+
+Disable XML-RPC by Progress Planner is a focused utility plugin for WordPress sites that do not need XML-RPC enabled.
+
+Once activated, the plugin disables XML-RPC and blocks XML-RPC requests with a 403 response. There are no settings to configure and no ongoing maintenance inside wp-admin.
+
+If you are hardening a site and do not rely on XML-RPC-based publishing or integrations, this plugin offers a simple way to turn that functionality off.
+
+= Why site owners install this plugin =
+
+* Disable XML-RPC completely
+* Reduce unnecessary exposure on sites that do not use XML-RPC
+* Activate once and leave it alone
+* No settings page or configuration required
+* Minimal plugin footprint
+
+= Important compatibility note =
+
+Do not activate this plugin if your site depends on XML-RPC for publishing tools, apps, or integrations.
+
+== Installation ==
+
+1. Upload the plugin files to the `/wp-content/plugins/pp-disable-xml-rpc` directory, or install the plugin through the WordPress plugins screen.
+2. Activate the plugin through the **Plugins** screen in WordPress.
+3. The plugin starts working immediately. No further setup is required.
+
+== Frequently Asked Questions ==
+
+= What does this plugin do? =
+
+It disables WordPress XML-RPC and blocks direct XML-RPC requests.
+
+= Does this plugin have settings? =
+
+No. This plugin is intentionally configuration-free.
+
+= Should I use this on every site? =
+
+Only if the site does not rely on XML-RPC. If any connected service or workflow still uses XML-RPC, disabling it may cause issues.
+
+= Does this replace a full security plugin? =
+
+No. It is a small hardening utility, not a full security suite.
+
+== Changelog ==
+
+= 1.6.1 =
+* Current stable release.
+
+== Upgrade Notice ==
+
+= 1.6.1 =
+A lightweight release that disables XML-RPC with no configuration required.


### PR DESCRIPTION
## Summary
- replace the sparse GitHub README with a proper landing page
- add a WordPress.org readme with stronger copy and FAQ
- improve plugin metadata for discoverability

## Testing
- not needed (copy and metadata only)