### PR TITLE
Add baseline GitHub Actions checks

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,35 @@
+name: PHP Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: php-parallel-lint
+          coverage: none
+
+      - name: Lint PHP files
+        run: parallel-lint .

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: php-parallel-lint
+          tools: parallel-lint
           coverage: none
 
       - name: Lint PHP files

--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,0 +1,29 @@
+name: WordPress Coding Standards
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpcs:
+    name: WPCS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: WPCS check
+        uses: 10up/wpcs-action@stable
+        with:
+          enable_warnings: true
+          standard: WordPress
+          only_changed_lines: true

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "progressplanner/pp-disable-xml-rpc",
+    "description": "A utility plugin to disable XML-RPC in WordPress.",
+    "type": "wordpress-plugin",
+    "homepage": "https://progressplanner.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Team Emilia Projects",
+            "homepage": "https://prpl.fyi/about"
+        }
+    ],
+    "require": {
+        "php": ">=7.4"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
## Summary
- add WordPress coding standards checks
- add PHP linting across supported PHP versions

## Why
This repo already had deploy and Playground workflows, but it was still missing basic automated code-quality checks.